### PR TITLE
HKDF fixed

### DIFF
--- a/disco/crypto.go
+++ b/disco/crypto.go
@@ -121,6 +121,6 @@ func hkdf(chainingKey, inputKeyMaterial []byte, numOutputs int) (output []byte) 
 	if numOutputs == 2 {
 		return
 	}
-	output = append(output, hmacHash(tempKey, append(output, 0x03))...)
+	output = append(output, hmacHash(tempKey, append(output[32:], 0x03))...)
 	return
 }

--- a/readable/crypto.go
+++ b/readable/crypto.go
@@ -121,6 +121,6 @@ func hkdf(chainingKey, inputKeyMaterial []byte, numOutputs int) (output []byte) 
 	if numOutputs == 2 {
 		return
 	}
-	output = append(output, hmacHash(tempKey, append(output, 0x03))...)
+	output = append(output, hmacHash(tempKey, append(output[32:], 0x03))...)
 	return
 }


### PR DESCRIPTION
You might want to change it to ```output[len(tempKey):]``` in case the HMAC changes from using SHA256, but that's probably not going to happen so meh.