### PR TITLE
Retrieve long term static key for Conn

### DIFF
--- a/noise/conn.go
+++ b/noise/conn.go
@@ -361,7 +361,7 @@ func (c *Conn) StaticKey() ([]byte, error) {
 	if !c.handshakeComplete {
 		return nil, errors.New("noise: handshake not completed")
 	}
-	if c.remotePubSet {
+	if !c.remotePubSet {
 		return nil, errors.New("noise: no remote static key given")
 	}
 	return c.remotePub[:], nil

--- a/noise/conn.go
+++ b/noise/conn.go
@@ -17,7 +17,7 @@ type Conn struct {
 	// handshake
 	config            *Config // configuration passed to constructor
 	hs                handshakeState
-	remotePub         []byte
+	remotePub         [32]byte
 	handshakeComplete bool
 	handshakeMutex    sync.Mutex
 
@@ -320,8 +320,6 @@ ContinueHandshake:
 			if !c.config.PublicKeyVerifier(hs.rs.PublicKey[:], receivedPayload) {
 				return errors.New("Noise: the received public key could not be authenticated")
 			}
-			c.isRemoteAuthenticated = true
-			c.remotePub = make([]byte, 32)
 			copy(c.remotePub, hs.rs.PublicKey[:])
 		}
 	}
@@ -358,9 +356,6 @@ func (c *Conn) IsRemoteAuthenticated() bool {
 // StaticKey returns the static key of the remote peer. It is useful in case the
 // static key is only transmitted during the handshake.
 func (c *Conn) StaticKey() ([]byte, error) {
-	if !c.IsRemoteAuthenticated() {
-		return nil, errors.New("noise: remote peer not authenticated")
-	}
 	if !c.handshakeComplete {
 		return nil, errors.New("noise: handshake not completed")
 	}

--- a/noise/noise.go
+++ b/noise/noise.go
@@ -232,7 +232,6 @@ type handshakeState struct {
 // * s, e, rs, re are the local and remote static/ephemeral key pairs to be set (if they exist)
 // the function returns a handshakeState object.
 func initialize(handshakeType noiseHandshakeType, initiator bool, prologue []byte, s, e, rs, re *KeyPair) (h handshakeState) {
-
 	handshakePattern, ok := patterns[handshakeType]
 	if !ok {
 		panic("Noise: the supplied handshakePattern does not exist")
@@ -499,8 +498,5 @@ func (h *handshakeState) clear() {
 func (kp *KeyPair) clear() {
 	for i := 0; i < len(kp.PrivateKey); i++ {
 		kp.PrivateKey[i] = 0
-	}
-	for i := 0; i < len(kp.PublicKey); i++ {
-		kp.PublicKey[i] = 0
 	}
 }

--- a/noise/patterns_test.go
+++ b/noise/patterns_test.go
@@ -191,7 +191,13 @@ func TestNoiseXX(t *testing.T) {
 		if _, err = serverSocket.Write([]byte("ca va?")); err != nil {
 			t.Fatal("server can't write on socket")
 		}
-
+		clientStatic, err := serverSocket.(*Conn).StaticKey()
+		if err != nil {
+			t.Fatal("client static key not retrieved")
+		}
+		if !bytes.Equal(clientStatic, clientKeyPair.PublicKey[:]) {
+			t.Fatal("client static retrieved not correct")
+		}
 	}()
 
 	// Run the client
@@ -210,6 +216,15 @@ func TestNoiseXX(t *testing.T) {
 	}
 	if !bytes.Equal(buf[:n], []byte("ca va?")) {
 		t.Fatal("server message failed")
+	}
+
+	serverStatic, err := clientSocket.StaticKey()
+	if err != nil {
+		t.Fatal("server static key not retrieved after exchange", err)
+	}
+
+	if !bytes.Equal(serverStatic, serverKeyPair.PublicKey[:]) {
+		t.Fatal("static key received different than server's one")
 	}
 }
 

--- a/noise/patterns_test.go
+++ b/noise/patterns_test.go
@@ -196,7 +196,7 @@ func TestNoiseXX(t *testing.T) {
 			t.Fatal("client static key not retrieved")
 		}
 		if !bytes.Equal(clientStatic, clientKeyPair.PublicKey[:]) {
-			t.Fatal("client static retrieved not correct")
+			t.Fatalf("client static retrieved not correct %x", clientStatic)
 		}
 	}()
 
@@ -224,7 +224,7 @@ func TestNoiseXX(t *testing.T) {
 	}
 
 	if !bytes.Equal(serverStatic, serverKeyPair.PublicKey[:]) {
-		t.Fatal("static key received different than server's one")
+		t.Fatalf("(conn %p) static key received different than server's one %x", clientSocket, serverStatic)
 	}
 }
 


### PR DESCRIPTION
Hi David! 

It's Nicolas, working at EPFL, we met  @RWC18. 
Thank you for this library, especially the `net.Conn` interface, that's what made me change to go here ;)

However, with this PR, I'd like to add the possiblity of getting the static key which is sent during a handshake after the handshake's completed. It's especially useful on the server side (listening side) when all static keys are known, which peer contacted us. 

I hope it's still correct. Especially the `isAuthenticated = true`, it may not be necessary but I was thinking that it should be there..

 Looking forwards to your comments !